### PR TITLE
Fix indexing into objects with non-slice things

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -3342,6 +3342,12 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
                 self.visit (dim)
             self.emit (']')
             self.emit (')')
+        else:
+            # simple indexing with a constant or value
+            self.visit (node.value)
+            self.emit ('[')
+            self.visit (node.slice)
+            self.emit (']')
 
     def visit_Try (self, node):
         self.adaptLineNrString (node)


### PR DESCRIPTION
This allows the following Python code to compile and work:

```python
obj = {"a": "hello"}
print(obj["a"])
```

This was previously compiled to:

```javascript
export var obj=dict([["a","hello"]]);
print();
```

With this PR, it will now be compiled to:

```javascript
export var obj=dict([["a","hello"]]);
print(obj["a"]);
```