### PR TITLE
Add start argument to builtin enumerate function to match CPython

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/module_builtin/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/module_builtin/__init__.py
@@ -108,3 +108,9 @@ def run (autoTester):
     autoTester.check("123".isalpha())
     autoTester.check("abc".isalpha())
     autoTester.check("abc123".isalpha())
+
+    enumerate_list = ['a', 'b', 'c', 'd', 'e']
+    # JS does not have tuples so coerce  to list of lists
+    autoTester.check([list(item) for item in enumerate(enumerate_list)])
+    autoTester.check([list(item) for item in enumerate(enumerate_list, 1)])
+    autoTester.check([list(item) for item in enumerate(enumerate_list, start=2)])

--- a/transcrypt/modules/org/transcrypt/__builtin__.js
+++ b/transcrypt/modules/org/transcrypt/__builtin__.js
@@ -916,8 +916,12 @@ export function sum (iterable) {
 }
 
 // Enumerate method, returning a zipped list
-export function enumerate (iterable) {
-    return zip (range (len (iterable)), iterable);
+export function enumerate(iterable, start = 0) {
+    if (start.hasOwnProperty("__kwargtrans__")) {
+        // start was likely passed in as kwarg
+        start = start['start'];
+    }
+    return zip(range(start, len(iterable) + start), iterable);
 }
 
 // Shallow and deepcopy


### PR DESCRIPTION
Add `start` argument to `enumerate` function in _\_\_builtin\_\_.js_
Add autotests for `enumerate` function to _module_builtin_

Fixes issue https://github.com/QQuick/Transcrypt/issues/804